### PR TITLE
Filters cannot use `type` to filter events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
  - Plugins were updated to follow the new shutdown semantic, this mainly allows Logstash to instruct input plugins to terminate gracefully, 
    instead of using Thread.raise on the plugins' threads. Ref: https://github.com/elastic/logstash/pull/3895
  - Dependency on logstash-core update to 2.0
+ - Remove the test for filtering on the `type` since we are removing the `filter?`
 
 1.0.0
   - Use @metadata instead of root-level fields

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
+## 2.0.2
+ - Filtering using `tags` or `type` option is now deprecated, please use conditionals Ref: https://github.com/elastic/logstash/pull/4011
 ## 2.0.0
  - Plugins were updated to follow the new shutdown semantic, this mainly allows Logstash to instruct input plugins to terminate gracefully, 
    instead of using Thread.raise on the plugins' threads. Ref: https://github.com/elastic/logstash/pull/3895
  - Dependency on logstash-core update to 2.0
- - Remove the test for filtering on the `type` since we are removing the `filter?`
 
 1.0.0
   - Use @metadata instead of root-level fields

--- a/logstash-filter-environment.gemspec
+++ b/logstash-filter-environment.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-environment'
-  s.version         = '2.0.1'
+  s.version         = '2.0.2'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Set fields from environment variables"
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"

--- a/spec/filters/environment_spec.rb
+++ b/spec/filters/environment_spec.rb
@@ -21,23 +21,4 @@ describe LogStash::Filters::Environment do
       insist { subject["@metadata"]["newfield"] } == "hello world"
     end
   end
-
-  describe "does nothing on non-matching events" do
-    # The logstash config goes here.
-    # At this time, only filters are supported.
-    config <<-CONFIG
-      filter {
-        environment {
-          type => "foo"
-          add_metadata_from_env => [ "newfield", "MY_ENV_VAR" ]
-        }
-      }
-    CONFIG
-
-    ENV["MY_ENV_VAR"] = "hello world"
-
-    sample("type" => "bar", "message" => "fizz") do
-      insist { subject["@metadata"]["newfield"] }.nil?
-    end
-  end
 end


### PR DESCRIPTION
Since we are removing the `filter?` method in the base class,
users will need to to update their configuration and use conditionals
instead of the `type` option.

Example:

```
filter {
  environment {
    type => "foo"
    add_metadata_from_env => [ "newfield", "MY_ENV_VAR" ]
  }
}
```

Become

```
filter {
  if [type] == "foo" {
    environment {
      type => "foo"
      add_metadata_from_env => [ "newfield", "MY_ENV_VAR" ]
    }
  }
}
```
