### PR TITLE
Work with the plugin api 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 sudo: false
 language: ruby
 cache: bundler
+jdk: oraclejdk8
 rvm:
-  - jruby-1.7.23
+  - jruby-1.7.25
 script: 
   - bundle exec rspec spec

--- a/lib/logstash/filters/environment.rb
+++ b/lib/logstash/filters/environment.rb
@@ -9,7 +9,7 @@ require "logstash/namespace"
 # Adding environment variables is as easy as:
 #    filter {
 #      environment {
-#        add_metadata_from_env { "field_name" => "ENV_VAR_NAME" }
+#        add_metadata_from_env => { "field_name" => "ENV_VAR_NAME" }
 #      }
 #    }
 #
@@ -30,11 +30,11 @@ class LogStash::Filters::Environment < LogStash::Filters::Base
   # Specify a hash of field names and the environment variable name with the
   # value you want imported into Logstash. For example:
   #
-  #    add_metadata_from_env { "field_name" => "ENV_VAR_NAME" }
+  #    add_metadata_from_env => { "field_name" => "ENV_VAR_NAME" }
   #
   # or
   #
-  #    add_metadata_from_env {
+  #    add_metadata_from_env => {
   #      "field1" => "ENV1"
   #      "field2" => "ENV2"
   #      # "field_n" => "ENV_n"
@@ -50,7 +50,7 @@ class LogStash::Filters::Environment < LogStash::Filters::Base
   def filter(event)
     
     @add_metadata_from_env.each do |field, env|
-      event["[@metadata][#{field}]"] = ENV[env]
+      event.set("[@metadata][#{field}]", ENV[env])
     end
     filter_matched(event)
   end # def filter

--- a/logstash-filter-environment.gemspec
+++ b/logstash-filter-environment.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.metadata = { "logstash_plugin" => "true", "logstash_group" => "filter" }
 
   # Gem dependencies
-  s.add_runtime_dependency "logstash-core-plugin-api", "~> 1.0"
+  s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
 
   s.add_development_dependency 'logstash-devutils'
 end

--- a/spec/filters/environment_spec.rb
+++ b/spec/filters/environment_spec.rb
@@ -18,7 +18,7 @@ describe LogStash::Filters::Environment do
     CONFIG
 
     sample "example" do
-      insist { subject["@metadata"]["newfield"] } == "hello world"
+      insist { subject.get("[@metadata][newfield]") } == "hello world"
     end
   end
 end


### PR DESCRIPTION
I have made some changes to be working with the plugin api 2.0 in order to align to the 5.0-alpha5 release.

**Local Testing Result**

```
$ echo "abcdefg" | MY_ENV="my_env_value" bin/logstash -e 'filter{ environment {add_metadata_from_env => { "event_type" => "MY_ENV" } } } output { stdout { codec => rubydebug { metadata => true } } }'
--- jar coordinate com.fasterxml.jackson.core:jackson-annotations already loaded with version 2.7.1 - omit version 2.7.0
--- jar coordinate com.fasterxml.jackson.core:jackson-databind already loaded with version 2.7.1 - omit version 2.7.1-1
Pipeline main started
{
    "@timestamp" => 2016-08-09T23:56:08.640Z,
     "@metadata" => {
        "event_type" => "my_env_value"
    },
      "@version" => "1",
          "host" => "Koshos-MacBook-Pro-1694.local",
       "message" => "abcdefg",
          "type" => "stdin"
}
Pipeline main has been shutdown
stopping pipeline {:id=>"main", :level=>:warn}
```
